### PR TITLE
ArcanistESLintLinter uses the wrong path for running commands

### DIFF
--- a/src/linters/ArcanistESLintLinter.php
+++ b/src/linters/ArcanistESLintLinter.php
@@ -45,7 +45,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
     }
 
     public function getInstallInstructions() {
-        return pht('Install ESLint using `%s`.', 'npm install eslint');
+        return pht('Make sure you have ESLint installed.');
     }
 
     public function getMandatoryFlags() {

--- a/src/linters/ArcanistESLintLinter.php
+++ b/src/linters/ArcanistESLintLinter.php
@@ -23,7 +23,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
     }
 
     public function getVersion() {
-        $output = exec('eslint --version');
+        list($output) = execx('%C --version', $this->getExecutableCommand());
 
         if (strpos($output, 'command not found') !== false) {
             return false;
@@ -45,7 +45,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
     }
 
     public function getInstallInstructions() {
-        return pht('Install ESLint using `%s`.', 'npm install -g eslint eslint-plugin-react');
+        return pht('Install ESLint using `%s`.', 'npm install eslint');
     }
 
     public function getMandatoryFlags() {


### PR DESCRIPTION
We can specify a local installation of `eslint` for Arcanist now, but it throws an error message because the `eslint --version` doesn't go to the right eslint. This configuration change will allow us to respect the `bin` argument to go to the local `eslint` binary.